### PR TITLE
Switch to HF hub models

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,15 @@ torchrun --standalone --nproc_per_node=8 train_sgp.py --model_name <model> --exi
 ## Vicuna-7B as an example
 
 ## Vanilla decoding
-CUDA_VISIBLE_DEVICES=0 python -m evaluation.inference_baseline --model-path "/cache/CKPT/vicuna-7b-v1.3" --model-id "vicuna-7b-v1.3-vanilla-float16-temp-0.0" --bench-name "Kangaroo" --temperature 0.0 --dtype "float16"
+CUDA_VISIBLE_DEVICES=0 python -m evaluation.inference_baseline --model-path lmsys/vicuna-7b-v1.3 --model-id "vicuna-7b-v1.3-vanilla-float16-temp-0.0" --bench-name "Kangaroo" --temperature 0.0 --dtype "float16"
 
 ## Kangaroo
-CUDA_VISIBLE_DEVICES=0 python -m evaluation.inference_kangaroo --adapter-path "/cache/CKPT/kangaroo-vicuna-7b-v1.3" --exitlayer 2 --model-path "/cache/CKPT/vicuna-7b-v1.3" --threshold 0.6 --steps 6 --model-id "vicuna-7b-v1.3-kangaroo-thres-0.6-steps-6-float16" --bench-name "Kangaroo" --dtype "float16"
+CUDA_VISIBLE_DEVICES=0 python -m evaluation.inference_kangaroo --adapter-path SafeAILab/kangaroo-vicuna-7b-v1.3 --exitlayer 2 --model-path lmsys/vicuna-7b-v1.3 --threshold 0.6 --steps 6 --model-id "vicuna-7b-v1.3-kangaroo-thres-0.6-steps-6-float16" --bench-name "Kangaroo" --dtype "float16"
 ```
 
 To get the detailed speed information, run ``python evaluation/speed.py``.
 
-The corresponding huggingface ckpts of kangaroo can be downloaded at [Kangaroo Google Drive](https://drive.google.com/drive/folders/1_lSqhasWeIUyfCft50JtKuQ2-TWepm8p?usp=sharing).
+The official Kangaroo checkpoints are hosted on [Hugging Face](https://huggingface.co/SafeAILab).
 
 
 #### Citation

--- a/evaluation/inference_baseline.py
+++ b/evaluation/inference_baseline.py
@@ -1,4 +1,4 @@
-"""Generate answers with local models.
+"""Generate answers with models from HuggingFace.
 
 Usage:
 python3 gen_model_answer.py --model-path lmsys/fastchat-t5-3b-v1.0 --model-id fastchat-t5-3b-v1.0

--- a/evaluation/inference_kangaroo.py
+++ b/evaluation/inference_kangaroo.py
@@ -1,4 +1,4 @@
-"""Generate answers with local models.
+"""Generate answers with models from HuggingFace.
 
 Usage:
 python3 gen_model_answer.py --model-path lmsys/fastchat-t5-3b-v1.0 --model-id fastchat-t5-3b-v1.0

--- a/evaluation/speed.py
+++ b/evaluation/speed.py
@@ -69,13 +69,13 @@ def speed(jsonl_file, jsonl_file_base, tokenizer, task=None, report=True):
 
 
 def get_single_speedup(jsonl_file, jsonl_file_base):
-    tokenizer_path="/cache/CKPT/vicuna-7b-v1.3/"
+    tokenizer_path="lmsys/vicuna-7b-v1.3"
     for subtask_name in ["mt_bench", "translation", "summarization", "qa", "math_reasoning", "rag", "overall"]:
         speed(jsonl_file, jsonl_file_base, tokenizer_path, task=subtask_name)
 
 
 def get_mean_speedup():
-    tokenizer_path="/cache/CKPT/vicuna-7b-v1.3/"
+    tokenizer_path="lmsys/vicuna-7b-v1.3"
     jsonl_file_name = "vicuna-7b-v1.3-lade-level-5-win-7-guess-7-float16.jsonl"
     jsonl_file_base_name = "vicuna-7b-v1.3-vanilla-float16-temp-0.0.jsonl"
     jsonl_file_run_list = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ openai
 sentencepiece
 peft
 datasets
+huggingface_hub


### PR DESCRIPTION
## Summary
- load adapter and head weights using `hf_hub_download`
- update evaluation scripts to use HuggingFace model ids
- reference HuggingFace repos in README examples
- add huggingface-hub dependency

## Testing
- `python -m py_compile kangaroo/kangaroo_model.py evaluation/speed.py evaluation/inference_baseline.py evaluation/inference_kangaroo.py train_sgp.py train.py start_train.py`

------
https://chatgpt.com/codex/tasks/task_e_685e51cdf550832489e88df75cff0c39