### PR TITLE
Use HF datasets/models for SGP

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We follow the training procedure of [Medusa](https://github.com/FasterDecoding/M
 
 ```python
 cd data
-python allocation.py --outdir /home/ma-user/work/Data/
+python allocation.py --outdir <output_path>
 ```
 
 2. training
@@ -54,8 +54,11 @@ python start_train.py
 
 #### Shallow-Gradient-Path Fine-Tuning
 
+Train a LoRA adapter on the [Databricks Dolly 15k](https://huggingface.co/datasets/databricks/databricks-dolly-15k)
+dataset using any HuggingFace model:
+
 ```
-torchrun --standalone --nproc_per_node=8 train_sgp.py --model_name <model> --exit_layer 6
+python train_sgp.py --model_name <hf_model_name> --exit_layer 6
 ```
 
 

--- a/data/allocation.py
+++ b/data/allocation.py
@@ -1,7 +1,8 @@
 import argparse
 
-parser = argparse.ArgumentParser(description='sp')
-parser.add_argument('--outdir', type=str, default='/home/ma-user/work/Data/')
+parser = argparse.ArgumentParser(description='Preprocess data')
+parser.add_argument('--outdir', type=str, required=True,
+                    help='Output directory for processed data')
 args = parser.parse_args()
 
 import os

--- a/data/dolly_loader.py
+++ b/data/dolly_loader.py
@@ -4,6 +4,9 @@ import torch
 
 
 def build(tokenizer, batch: int, seq: int):
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
     ds = load_dataset("databricks/databricks-dolly-15k", split="train")
 
     def _format(example):

--- a/start_train.py
+++ b/start_train.py
@@ -2,7 +2,8 @@ import os, torch, shutil, glob, time
 import argparse
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--data_home", type=str, default="/home/heck2/sbhansali8/Shallow-Spec/data/test/Data/")
+parser.add_argument("--data_home", type=str, required=True,
+                    help="Path to training data (generated hidden states)")
 parser.add_argument("--start_epoch", type=int, default=0)
 parser.add_argument("--end_epoch", type=int, default=20)
 parser.add_argument("--bs", type=int, default=4)

--- a/train_sgp.py
+++ b/train_sgp.py
@@ -27,7 +27,7 @@ def main():
     tokenizer.pad_token = tokenizer.eos_token
 
     dummy = argparse.Namespace(dtype="bfloat16")
-    model = KangarooModel(args.model_name, args.model_name, dummy, EARLY_STOP_LAYER=args.exit_layer)
+    model = KangarooModel(args.model_name, None, dummy, EARLY_STOP_LAYER=args.exit_layer)
     model.base_model = inject_lora(model.base_model, args.exit_layer)
     model.base_model.gradient_checkpointing_enable()
 


### PR DESCRIPTION
## Summary
- load Dolly from HF and set a pad token automatically
- support initializing adapters from scratch
- robustly load head weights from HF checkpoints
- drop hardcoded local paths in data tools
- update README quick-start instructions

## Testing
- `python -m py_compile data/allocation.py data/dolly_loader.py kangaroo/kangaroo_model.py start_train.py train_sgp.py`
- `python train_sgp.py --model_name hf-internal-testing/tiny-random-LlamaForCausalLM --exit_layer 1 --epochs 1 --per_device_batch 1 --detach-exit --beta_exit 0.1` *(fails: KeyboardInterrupt during dataset map)*

------
https://chatgpt.com/codex/tasks/task_e_685f0a952f2483248be4128035cb7e39