### PR TITLE
Update SGP instructions to use HF data

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We follow the training procedure of [Medusa](https://github.com/FasterDecoding/M
 
 ```python
 cd data
-python allocation.py --outdir /home/ma-user/work/Data/
+python allocation.py --outdir ./output
 ```
 
 2. training
@@ -55,8 +55,10 @@ python start_train.py
 #### Shallow-Gradient-Path Fine-Tuning
 
 ```
-torchrun --standalone --nproc_per_node=8 train_sgp.py --model_name <model> --exit_layer 6
+python train_sgp.py --model_name <model> --exit_layer 6
 ```
+The script downloads **databricks/databricks-dolly-15k** automatically and trains
+a LoRA adapter on the chosen model.
 
 
 #### Inference

--- a/data/allocation.py
+++ b/data/allocation.py
@@ -1,7 +1,8 @@
 import argparse
 
 parser = argparse.ArgumentParser(description='sp')
-parser.add_argument('--outdir', type=str, default='/home/ma-user/work/Data/')
+# default output directory no longer assumes a fixed absolute path
+parser.add_argument('--outdir', type=str, default='./output')
 args = parser.parse_args()
 
 import os

--- a/start_train.py
+++ b/start_train.py
@@ -2,7 +2,9 @@ import os, torch, shutil, glob, time
 import argparse
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--data_home", type=str, default="/home/heck2/sbhansali8/Shallow-Spec/data/test/Data/")
+# default to a relative directory so training does not rely on a specific local
+# filesystem layout
+parser.add_argument("--data_home", type=str, default="./data/test/Data/")
 parser.add_argument("--start_epoch", type=int, default=0)
 parser.add_argument("--end_epoch", type=int, default=20)
 parser.add_argument("--bs", type=int, default=4)


### PR DESCRIPTION
## Summary
- avoid hard-coded absolute paths in `allocation.py` and `start_train.py`
- simplify README instructions for SGP fine tuning

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python train_sgp.py --help`

------
https://chatgpt.com/codex/tasks/task_e_685f0a952f2483248be4128035cb7e39