### PR TITLE
fix evaluation module path resolution

### DIFF
--- a/evaluation/sgp_eval.py
+++ b/evaluation/sgp_eval.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from kangaroo.kangaroo_model import KangarooModel
+
+
+def main():
+    print("SGP evaluation placeholder")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a minimal `sgp_eval.py` script
- ensure module path resolution works when run directly

## Testing
- `python -m py_compile evaluation/sgp_eval.py`

------
https://chatgpt.com/codex/tasks/task_e_6861fa31a6c0832498d8a0969f0848ac