### PR TITLE
Fix evaluation path resolution

### DIFF
--- a/evaluation/sgp_eval.py
+++ b/evaluation/sgp_eval.py
@@ -1,7 +1,10 @@
 import argparse
 import json
 import time
+import sys
 from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import torch
 from datasets import load_dataset


### PR DESCRIPTION
## Summary
- ensure `sgp_eval.py` can find `kangaroo` when executed from different paths

## Testing
- `python -m py_compile evaluation/sgp_eval.py`


------
https://chatgpt.com/codex/tasks/task_e_6861fd692a388324804920b25a084864