### PR TITLE
Implement ReplayBuffer and unit tests

### DIFF
--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1,0 +1,55 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import torch
+import pytest
+
+from training.buffer import ReplayBuffer
+
+
+def test_append_wraparound():
+    buf = ReplayBuffer(capacity=3, device=torch.device('cpu'))
+    for i in range(4):
+        buf.append(torch.full((2,), float(i)), token=i, reward=float(i % 2), conf=0.0)
+    assert len(buf) == 3
+    tokens = buf._token_buf[: len(buf)].tolist()
+    assert sorted(tokens) == [1, 2, 3]
+    assert buf.accepted_count() == 2
+
+
+def test_accepted_count():
+    buf = ReplayBuffer(capacity=4, device=torch.device('cpu'))
+    rewards = [1.0, 0.0, 1.0]
+    for i, r in enumerate(rewards):
+        buf.append(torch.zeros(1), token=i, reward=r, conf=0.0)
+    assert buf.accepted_count() == 2
+
+
+def test_sample_shapes_and_dtypes():
+    buf = ReplayBuffer(capacity=5, device=torch.device('cpu'))
+    for i in range(5):
+        buf.append(torch.zeros(4), token=i, reward=1.0, conf=0.5)
+    batch = buf.sample(3)
+    assert batch['hidden'].shape == (3, 4)
+    assert batch['token'].dtype == torch.long
+    assert batch['reward'].dtype == torch.float32
+    assert batch['conf'].dtype == torch.float32
+
+
+def test_clear_all():
+    buf = ReplayBuffer(capacity=3, device=torch.device('cpu'))
+    for i in range(3):
+        buf.append(torch.zeros(1), token=i, reward=1.0, conf=0.0)
+    buf.clear()
+    assert len(buf) == 0
+    assert buf.accepted_count() == 0
+
+
+def test_clear_accepted_only():
+    buf = ReplayBuffer(capacity=5, device=torch.device('cpu'))
+    rewards = [1.0, 0.0, 1.0, 0.0]
+    for i, r in enumerate(rewards):
+        buf.append(torch.zeros(1), token=i, reward=r, conf=0.0)
+    buf.clear(accepted_only=True)
+    assert buf.accepted_count() == 0
+    tokens = buf._token_buf[: len(buf)].tolist()
+    assert tokens == [1, 3]

--- a/training/buffer.py
+++ b/training/buffer.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import Dict
+import torch
+
+class ReplayBuffer:
+    """Small circular replay buffer for DVI-RL.
+
+    Parameters
+    ----------
+    capacity: int
+        Maximum number of entries stored.
+    device: torch.device
+        Device on which tensors are stored.
+
+    Example
+    -------
+    >>> buf = ReplayBuffer(capacity=4, device=torch.device('cpu'))
+    >>> h = torch.randn(2)
+    >>> buf.append(h, token=1, reward=1.0, conf=0.9)
+    >>> len(buf)
+    1
+    >>> sample = buf.sample(1)
+    >>> list(sample.keys())
+    ['hidden', 'token', 'reward', 'conf']
+    """
+
+    def __init__(self, capacity: int, device: torch.device) -> None:
+        self.capacity = int(capacity)
+        self.device = device
+        self._next_idx = 0
+        self._size = 0
+        self._hidden_buf: torch.Tensor | None = None
+        self._token_buf: torch.Tensor | None = None
+        self._reward_buf: torch.Tensor | None = None
+        self._conf_buf: torch.Tensor | None = None
+
+    def _allocate(self, hidden: torch.Tensor) -> None:
+        shape = (self.capacity,) + hidden.shape
+        self._hidden_buf = torch.empty(
+            shape, dtype=hidden.dtype, device=self.device
+        )
+        self._token_buf = torch.empty(
+            self.capacity, dtype=torch.long, device=self.device
+        )
+        self._reward_buf = torch.empty(
+            self.capacity, dtype=torch.float32, device=self.device
+        )
+        self._conf_buf = torch.empty(
+            self.capacity, dtype=torch.float32, device=self.device
+        )
+
+    def append(
+        self,
+        hidden: torch.Tensor,
+        token: int,
+        reward: float,
+        conf: float,
+    ) -> None:
+        if self._hidden_buf is None:
+            self._allocate(hidden.detach())
+        assert self._hidden_buf is not None
+        idx = self._next_idx
+        self._hidden_buf[idx] = hidden.detach().to(self.device)
+        self._token_buf[idx] = int(token)
+        self._reward_buf[idx] = float(reward)
+        self._conf_buf[idx] = float(conf)
+
+        self._next_idx = (self._next_idx + 1) % self.capacity
+        if self._size < self.capacity:
+            self._size += 1
+
+    def accepted_count(self) -> int:
+        if self._size == 0:
+            return 0
+        return int((self._reward_buf[: self._size] == 1).sum().item())
+
+    def __len__(self) -> int:
+        return self._size
+
+    def sample(self, batch_size: int, accepted_only: bool = True) -> Dict[str, torch.Tensor]:
+        if self._size == 0:
+            raise ValueError("Buffer is empty")
+        if accepted_only:
+            mask = self._reward_buf[: self._size] == 1
+            indices = mask.nonzero(as_tuple=False).squeeze(-1)
+        else:
+            indices = torch.arange(self._size, device=self.device)
+        if indices.numel() < batch_size:
+            raise ValueError("Insufficient samples for requested batch size")
+        perm = torch.randperm(indices.numel(), device=self.device)[:batch_size]
+        sel = indices[perm]
+        return {
+            "hidden": self._hidden_buf[sel],
+            "token": self._token_buf[sel],
+            "reward": self._reward_buf[sel],
+            "conf": self._conf_buf[sel],
+        }
+
+    def clear(self, accepted_only: bool = False) -> None:
+        if self._size == 0:
+            return
+        if not accepted_only:
+            self._next_idx = 0
+            self._size = 0
+            return
+        mask = self._reward_buf[: self._size] != 1
+        keep = mask.sum().item()
+        if keep:
+            self._hidden_buf[:keep] = self._hidden_buf[: self._size][mask]
+            self._token_buf[:keep] = self._token_buf[: self._size][mask]
+            self._reward_buf[:keep] = self._reward_buf[: self._size][mask]
+            self._conf_buf[:keep] = self._conf_buf[: self._size][mask]
+        self._size = int(keep)
+        self._next_idx = self._size % self.capacity
+
+    def to(self, device: torch.device) -> "ReplayBuffer":
+        self.device = device
+        if self._hidden_buf is not None:
+            self._hidden_buf = self._hidden_buf.to(device)
+            self._token_buf = self._token_buf.to(device)
+            self._reward_buf = self._reward_buf.to(device)
+            self._conf_buf = self._conf_buf.to(device)
+        return self


### PR DESCRIPTION
## Summary
- add small replay buffer implementation for RL training
- add unit tests covering replay buffer behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3040d5788324a6a8ee14263b7ed8