### PR TITLE
Implement dual LoRA adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Note that the main branch only has the training pipeline - the other branch has 
 
 Because the verifier layers (`> L`) run under the detached hidden state, they are **frozen**: no gradients, no weight updates, no extra memory.
 
+Dual LoRA adapters can be injected with `inject_dual_lora()`. Both `lora_S` and
+`lora_D` are active by default. Use `enable_lora_grads(model, "lora_S", True)`
+to unfreeze the shallow adapter while keeping the deep one frozen.
+
 
 ## Running the code
 

--- a/kangaroo/sgp_lora.py
+++ b/kangaroo/sgp_lora.py
@@ -1,4 +1,19 @@
-from peft import LoraConfig, get_peft_model
+from __future__ import annotations
+
+import re
+from typing import List, Tuple, Set
+
+
+_LAYER_RE = re.compile(r"(?:^|\.)(?:encoder\.)?layers\.(\d+)\.")
+
+
+def _extract_idx(name: str) -> int | None:
+    """Return layer index encoded in a parameter name."""
+    m = _LAYER_RE.search(name)
+    return int(m.group(1)) if m else None
+
+import torch
+from peft import LoraConfig, get_peft_model, PeftModel
 
 
 def inject_lora(base_model, exit_layer: int, r: int = 8, alpha: int = 16, dropout: float = 0.05):
@@ -25,3 +40,118 @@ def inject_lora(base_model, exit_layer: int, r: int = 8, alpha: int = 16, dropou
                     for p in module.parameters():
                         p.requires_grad = True
     return model
+
+
+def inject_dual_lora(
+    base_model: torch.nn.Module,
+    exit_layer: int,
+    *,
+    rank_fast: int = 8,
+    rank_slow: int = 8,
+    alpha: int = 16,
+    dropout: float = 0.05,
+) -> PeftModel:
+    """Inject two LoRA adapter groups into a model.
+
+    Args:
+        base_model: Base HuggingFace model to modify.
+        exit_layer: Index of the last draft layer.
+        rank_fast: LoRA rank for the shallow adapter family.
+        rank_slow: LoRA rank for the deep adapter family.
+        alpha: LoRA scaling factor.
+        dropout: LoRA dropout probability.
+
+    Returns:
+        The ``PeftModel`` with ``lora_S`` and ``lora_D`` adapters registered.
+    """
+
+    transformer = getattr(base_model, "model", base_model)
+    num_layers = len(transformer.layers)
+
+    cfg_s = LoraConfig(
+        r=rank_fast,
+        lora_alpha=alpha,
+        lora_dropout=dropout,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+        bias="none",
+        task_type="CAUSAL_LM",
+        layers_to_transform=list(range(exit_layer + 1)),
+        layers_pattern="layers",
+    )
+    peft_model = get_peft_model(base_model, cfg_s, adapter_name="lora_S")
+
+    cfg_d = LoraConfig(
+        r=rank_slow,
+        lora_alpha=alpha,
+        lora_dropout=dropout,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+        bias="none",
+        task_type="CAUSAL_LM",
+        layers_to_transform=list(range(exit_layer + 1, num_layers)),
+        layers_pattern="layers",
+    )
+    peft_model.add_adapter("lora_D", cfg_d)
+
+    # Activate BOTH adapters for every forward(). Inside the wrapped
+    # ``base_model`` this ensures LoRA weights for both families are used.
+    peft_model.base_model.set_adapter(["lora_S", "lora_D"])
+
+    for param in peft_model.parameters():
+        param.requires_grad = False
+
+    setattr(peft_model, "exit_layer", exit_layer)
+    return peft_model
+
+
+def get_lora_param_names(model: torch.nn.Module, prefix: str) -> Set[str]:
+    """Return LoRA parameter names containing ``prefix``.
+
+    Args:
+        model: The model with LoRA adapters.
+        prefix: Adapter prefix (``"lora_S"`` or ``"lora_D"``).
+
+    Returns:
+        Set of parameter names that belong to the specified adapter.
+    """
+
+    return {n for n, _ in model.named_parameters() if f".{prefix}." in n}
+
+
+def enable_lora_grads(model: PeftModel, family: str, enable: bool = True) -> None:
+    """(Un)freeze LoRA parameters belonging to a given adapter family."""
+    token = f".{family}."
+    for name, param in model.named_parameters():
+        if token in name and ("lora_A" in name or "lora_B" in name):
+            param.requires_grad = enable
+
+
+def split_lora_params(model: torch.nn.Module) -> Tuple[List[torch.nn.Parameter], List[torch.nn.Parameter]]:
+    """Split LoRA parameters into fast and slow groups.
+
+    Args:
+        model: PEFT model produced by :func:`inject_dual_lora`.
+
+    Returns:
+        A tuple ``(fast_params, slow_params)`` with parameters for the ``lora_S``
+        and ``lora_D`` adapters respectively.
+    """
+
+    exit_layer = getattr(model, "exit_layer", None)
+    if exit_layer is None:
+        raise AttributeError("Model missing `exit_layer` attribute")
+
+    fast_params: List[torch.nn.Parameter] = []
+    slow_params: List[torch.nn.Parameter] = []
+
+    for name, param in model.named_parameters():
+        if "lora_A" not in name and "lora_B" not in name:
+            continue
+        idx = _extract_idx(name)
+        if idx is None:
+            continue
+        if ".lora_S." in name and idx <= exit_layer:
+            fast_params.append(param)
+        elif ".lora_D." in name and idx > exit_layer:
+            slow_params.append(param)
+
+    return fast_params, slow_params

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ accelerate
 fschat
 openai
 sentencepiece
-peft
+peft>=0.6.0
 datasets
 huggingface_hub

--- a/tests/test_dual_lora.py
+++ b/tests/test_dual_lora.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForCausalLM, LlamaConfig
+import peft
+import packaging.version
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from kangaroo.sgp_lora import inject_dual_lora, split_lora_params, get_lora_param_names
+
+
+def _create_tiny_llama():
+    config = LlamaConfig(
+        vocab_size=32,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=6,
+        num_attention_heads=4,
+    )
+    model = AutoModelForCausalLM.from_config(config)
+    return model
+
+
+def test_dual_lora_injection():
+    model = _create_tiny_llama()
+    peft_model = inject_dual_lora(model, exit_layer=3, rank_fast=4, rank_slow=4)
+    fast, slow = split_lora_params(peft_model)
+
+    assert packaging.version.parse(peft.__version__) >= packaging.version.parse("0.6.0")
+
+    assert len(fast) > 0 and len(slow) > 0
+    for p in fast:
+        assert p.requires_grad is False
+    for p in slow:
+        assert p.requires_grad is False
+
+    fast_names = get_lora_param_names(peft_model, "lora_S")
+    slow_names = get_lora_param_names(peft_model, "lora_D")
+    assert fast_names.isdisjoint(slow_names)
+    assert set(peft_model.active_adapters) == {"lora_S", "lora_D"}
+
+    peft_model.eval()
+    tokens = torch.randint(0, peft_model.config.vocab_size, (1, 4))
+    with torch.no_grad():
+        logits_zero = peft_model(tokens).logits
+        for name, param in peft_model.named_parameters():
+            if ".lora_S." in name or ".lora_D." in name:
+                param.fill_(1.0)
+        logits_mod = peft_model(tokens).logits
+
+    assert not torch.allclose(logits_zero, logits_mod)


### PR DESCRIPTION
## Summary
- add layer index extraction helper and dual LoRA grad utilities
- activate both adapters in the wrapped model
- expose helper to toggle LoRA grads on demand
- update docs for dual adapters
- require `peft>=0.6.0`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3059417083248820717ecf52de1b