### PR TITLE
Implement SpecStep hook for speculative decoding

### DIFF
--- a/kangaroo/kangaroo_model.py
+++ b/kangaroo/kangaroo_model.py
@@ -99,6 +99,10 @@ class KangarooModel(nn.Module):
             self.head_model = self.head_model.half()
             self.exit_proj = self.exit_proj.half()
 
+        # Bind heads so spec_decode_step always finds them
+        self.base_model.exit_proj = self.exit_proj
+        self.base_model.head_model = self.head_model
+
     def forward(self, input_ids, labels=None, beta_exit=0.1, detach_exit=True):
         """Run the model with an early-exit head.
 

--- a/tests/test_hidden_hook.py
+++ b/tests/test_hidden_hook.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import torch
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Stub evaluation.eval to avoid import errors during tests.
+import types
+
+dummy_mod = types.ModuleType("evaluation.eval")
+dummy_mod.run_eval = lambda *a, **k: None
+dummy_mod.reorg_answer_file = lambda *a, **k: None
+sys.modules.setdefault("evaluation.eval", dummy_mod)
+
+from kangaroo.kangaroo_model import KangarooModel
+from evaluation.inference_kangaroo import kangaroo_forward
+from transformers import AutoTokenizer
+
+
+def test_hidden_hook():
+    model_name = "hf-internal-testing/tiny-random-LlamaModel"
+    tok = AutoTokenizer.from_pretrained(model_name)
+    tok.pad_token = tok.eos_token
+    dummy = type("obj", (), {"dtype": "float16"})()
+    kg = KangarooModel(model_name, None, dummy, EARLY_STOP_LAYER=1)
+    prompt = tok("Hello", return_tensors="pt")
+    kg.eval()
+    ids, new_tok, _, _, trace = kangaroo_forward(
+        prompt, kg, tok, max_new_tokens=4, do_sample=False, return_trace=True, EARLY_STOP_LAYER=1
+    )
+    assert len(trace) == new_tok
+    for step in trace:
+        assert step.hidden.shape[-1] == kg.base_model.config.hidden_size
+        assert step.logits.shape[-1] == tok.vocab_size
+        assert int(step.accept.item()) in (0, 1)
+


### PR DESCRIPTION
## Summary
- add `SpecStep` NamedTuple with hidden state, logits, accept flag and sampled token
- return the sampled token in `spec_decode_step` and guard missing attributes
- use the returned token when tracing and only monkey-patch during tracing
- comment on evaluation stub in unit test
- ensure heads are bound to the base model so speculative decoding works outside tracing
- fix trace length logic when returning hidden states

## Testing
- `pytest -q` *(fails: OSError downloading tiny model)*

------
https://chatgpt.com/codex/tasks/task_e_686c304de1588324b93b6e87293bfad3