### PR TITLE
Enhance DVI training logs

### DIFF
--- a/training/buffer.py
+++ b/training/buffer.py
@@ -56,10 +56,11 @@ class ReplayBuffer:
         token: int,
         reward: float,
         conf: float,
-    ) -> None:
+    ) -> bool:
         if self._hidden_buf is None:
             self._allocate(hidden.detach())
         assert self._hidden_buf is not None
+        dropped = self._size == self.capacity
         idx = self._next_idx
         self._hidden_buf[idx] = hidden.detach().to(self.device)
         self._token_buf[idx] = int(token)
@@ -69,6 +70,7 @@ class ReplayBuffer:
         self._next_idx = (self._next_idx + 1) % self.capacity
         if self._size < self.capacity:
             self._size += 1
+        return dropped
 
     def accepted_count(self) -> int:
         if self._size == 0:


### PR DESCRIPTION
## Summary
- add `--log_every` and `--debug_dump` CLI arguments
- write optional per-token debug dumps
- track running token stats and buffer drops
- log extended rl_buffer information
- return drop indicator from `ReplayBuffer.append`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780c128ae48324a0133948e0cfcb07